### PR TITLE
fix: use `self'.packages.go` for `golangci-lint`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   };
   outputs = inputs:
     inputs.parts.lib.mkFlake {inherit inputs;} {
-      perSystem = {pkgs, ...}: {
+      perSystem = {pkgs, self', ...}: {
         packages = {
           go = pkgs.go.overrideAttrs (_: rec {
             src = pkgs.fetchurl {
@@ -16,7 +16,7 @@
           });
           golangci-lint = pkgs.writeShellApplication {
             name = "golangci-lint";
-            runtimeInputs = [pkgs.go pkgs.golangci-lint];
+            runtimeInputs = [self'.packages.go pkgs.golangci-lint];
             text = ''exec golangci-lint "$@"'';
           };
         };


### PR DESCRIPTION
It makes more sense to use the updated version of go exposed by this flake rather than nixpkgs one which could potentially be outdated. Another alternative would be to make `packages` recursive and just use `go` instead of `self'`, but I tend to prefer going through `self` as it is more refactor-proof and makes it very explicit where the package comes from.