### PR TITLE
fix: update gopls package directory from nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719848872,
-        "narHash": "sha256-H3+EC5cYuq+gQW8y0lSrrDZfH71LB4DAf+TDFyvwCNA=",
+        "lastModified": 1722421184,
+        "narHash": "sha256-/DJBI6trCeVnasdjUo9pbnodCLZcFqnVZiLUfqLH4jA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "00d80d13810dbfea8ab4ed1009b09100cca86ba8",
+        "rev": "9f918d616c5321ad374ae6cb5ea89c9e04bf3e58",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
             runtimeInputs = [go pkgs.golangci-lint];
             text = ''exec golangci-lint "$@"'';
           };
-          gopls = pkgs.callPackage "${inputs.nixpkgs}/pkgs/development/tools/language-servers/gopls" {
+          gopls = pkgs.callPackage "${inputs.nixpkgs}/pkgs/by-name/go/gopls/package.nix" {
             inherit buildGoModule;
           };
         };


### PR DESCRIPTION
nixpkgs has updated the directory of the `gopls` package definition. Consumers of this flake that override the nixpkgs input are unable to build `gopls` because of this. The pinned nixpkgs version has been updated to reflect this as well.